### PR TITLE
Update example im_client-py

### DIFF
--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -48,7 +48,7 @@ user can specify the following parameters::
 	[im_client]
 	# only set one of the urls
 	#xmlrpc_url=http://localhost:8899
-	restapi_url==http://localhost:8800
+	restapi_url=http://localhost:8800
 	auth_file=auth.dat
 	xmlrpc_ssl_ca_certs=/tmp/pki/ca-chain.pem
 


### PR DESCRIPTION
The example before raised the error `No connection adapters were found for '=http://localhost:8800/infrastructures'`. There was an extra "=" on the host assignment.