### PR TITLE
Refactor deprecated unittest aliases for Python 3.11 compatibility.

### DIFF
--- a/test/integration/TestREST.py
+++ b/test/integration/TestREST.py
@@ -452,7 +452,7 @@ class TestIM(unittest.TestCase):
                          msg="ERROR getting TOSCA outputs:" + resp.text)
         res = json.loads(resp.text)
         server_url = str(res['outputs']['server_url'][0])
-        self.assertRegexpMatches(
+        self.assertRegex(
             server_url, '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}', msg="Unexpected outputs: " + resp.text)
 
     def test_95_add_tosca(self):

--- a/test/unit/connectors/Azure.py
+++ b/test/unit/connectors/Azure.py
@@ -217,20 +217,20 @@ class TestAzureConnector(TestCloudConnectorBase):
         self.assertTrue(res[0][0])
         self.assertTrue(res[1][0])
         self.assertTrue(res[2][0])
-        self.assertEquals(nclient.network_interfaces.begin_delete.call_count, 1)
+        self.assertEqual(nclient.network_interfaces.begin_delete.call_count, 1)
         self.assertIn("nic_name", nclient.network_interfaces.begin_delete.call_args_list[0][0][1])
 
         json_vm_req = cclient.virtual_machines.begin_create_or_update.call_args_list[0][0][2]
-        self.assertEquals(json_vm_req['storage_profile']['data_disks'][0]['disk_size_gb'], 1)
-        self.assertEquals(json_vm_req['storage_profile']['data_disks'][1]['managed_disk']['id'], "did")
+        self.assertEqual(json_vm_req['storage_profile']['data_disks'][0]['disk_size_gb'], 1)
+        self.assertEqual(json_vm_req['storage_profile']['data_disks'][1]['managed_disk']['id'], "did")
         image_res = {'sku': '16.04.0-LTS', 'publisher': 'Canonical', 'version': 'latest', 'offer': 'UbuntuServer'}
-        self.assertEquals(json_vm_req['storage_profile']['image_reference'], image_res)
-        self.assertEquals(json_vm_req['hardware_profile']['vm_size'], 'Standard_A1')
-        self.assertEquals(json_vm_req['os_profile']['admin_username'], 'user')
-        self.assertEquals(json_vm_req['os_profile']['admin_password'], 'pass')
-        self.assertEquals(json_vm_req['os_profile']['admin_password'], 'pass')
-        self.assertEquals(nclient.subnets.begin_create_or_update.call_args_list[0][0][3]['address_prefix'],
-                          '10.0.1.0/24')
+        self.assertEqual(json_vm_req['storage_profile']['image_reference'], image_res)
+        self.assertEqual(json_vm_req['hardware_profile']['vm_size'], 'Standard_A1')
+        self.assertEqual(json_vm_req['os_profile']['admin_username'], 'user')
+        self.assertEqual(json_vm_req['os_profile']['admin_password'], 'pass')
+        self.assertEqual(json_vm_req['os_profile']['admin_password'], 'pass')
+        self.assertEqual(nclient.subnets.begin_create_or_update.call_args_list[0][0][3]['address_prefix'],
+                         '10.0.1.0/24')
 
         radl_data = """
             network net1 (outbound = 'yes')
@@ -252,7 +252,7 @@ class TestAzureConnector(TestCloudConnectorBase):
         radl.check()
         with self.assertRaises(Exception) as ex:
             azure_cloud.launch(inf, radl, radl, 1, auth)
-        self.assertEquals(str(ex.exception), "Incorrect image url: it must be snapshot or disk.")
+        self.assertEqual(str(ex.exception), "Incorrect image url: it must be snapshot or disk.")
 
         radl_data = """
             network net1 (outbound = 'yes')
@@ -274,9 +274,9 @@ class TestAzureConnector(TestCloudConnectorBase):
         radl.check()
         res = azure_cloud.launch(inf, radl, radl, 1, auth)
         json_vm_req = cclient.virtual_machines.begin_create_or_update.call_args_list[5][0][2]
-        self.assertEquals(json_vm_req['storage_profile']['os_disk']['os_type'], 'linux')
-        self.assertEquals(nclient.subnets.begin_create_or_update.call_args_list[2][0][3]['address_prefix'],
-                          '192.168.1.0/24')
+        self.assertEqual(json_vm_req['storage_profile']['os_disk']['os_type'], 'linux')
+        self.assertEqual(nclient.subnets.begin_create_or_update.call_args_list[2][0][3]['address_prefix'],
+                         '192.168.1.0/24')
 
         radl_data = """
             network net1 (outbound = 'yes')
@@ -304,10 +304,10 @@ class TestAzureConnector(TestCloudConnectorBase):
         subnet_create.address_prefix = "10.0.1.0/24"
         nclient.subnets.get.return_value = subnet_create
         res = azure_cloud.launch(inf, radl, radl, 1, auth)
-        self.assertEquals(nclient.subnets.get.call_args_list[3][0][1], 'vnet')
-        self.assertEquals(nclient.subnets.get.call_args_list[3][0][2], 'subnet1')
-        self.assertEquals(nclient.subnets.begin_create_or_update.call_count, 3)
-        self.assertEquals(nclient.virtual_networks.begin_create_or_update.call_count, 3)
+        self.assertEqual(nclient.subnets.get.call_args_list[3][0][1], 'vnet')
+        self.assertEqual(nclient.subnets.get.call_args_list[3][0][2], 'subnet1')
+        self.assertEqual(nclient.subnets.begin_create_or_update.call_count, 3)
+        self.assertEqual(nclient.virtual_networks.begin_create_or_update.call_count, 3)
 
     @patch('IM.connectors.Azure.NetworkManagementClient')
     @patch('IM.connectors.Azure.ComputeManagementClient')
@@ -393,11 +393,11 @@ class TestAzureConnector(TestCloudConnectorBase):
         success, vm = azure_cloud.updateVMInfo(vm, auth)
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(dclient.zones.create_or_update.call_args_list,
-                          [call('rg0', 'domain.com', {'location': 'global'})])
-        self.assertEquals(dclient.record_sets.create_or_update.call_args_list,
-                          [call('rg0', 'domain.com', 'test', 'A',
-                                {'arecords': [{'ipv4_address': '13.0.0.1'}], 'ttl': 300})])
+        self.assertEqual(dclient.zones.create_or_update.call_args_list,
+                         [call('rg0', 'domain.com', {'location': 'global'})])
+        self.assertEqual(dclient.record_sets.create_or_update.call_args_list,
+                         [call('rg0', 'domain.com', 'test', 'A',
+                               {'arecords': [{'ipv4_address': '13.0.0.1'}], 'ttl': 300})])
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
     @patch('IM.connectors.Azure.ComputeManagementClient')
@@ -564,7 +564,7 @@ class TestAzureConnector(TestCloudConnectorBase):
         self.assertTrue(success, msg="ERROR: finalizing VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
-        self.assertEquals(cclient.virtual_machines.begin_delete.call_count, 2)
+        self.assertEqual(cclient.virtual_machines.begin_delete.call_count, 2)
         self.assertEqual(cclient.virtual_machines.begin_delete.call_args_list[0][0], ('rg0', 'vm0'))
         self.assertEqual(rclient.resource_groups.begin_delete.call_count, 1)
         self.assertEqual(rclient.resource_groups.begin_delete.call_args_list[0][0], ('rg0',))

--- a/test/unit/connectors/CloudStack.py
+++ b/test/unit/connectors/CloudStack.py
@@ -206,7 +206,7 @@ class TestOSCConnector(TestCloudConnectorBase):
         success, vm = osc_cloud.updateVMInfo(vm, auth)
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
     @patch('libcloud.compute.drivers.cloudstack.CloudStackNodeDriver')

--- a/test/unit/connectors/Docker.py
+++ b/test/unit/connectors/Docker.py
@@ -222,7 +222,7 @@ class TestDockerConnector(TestCloudConnectorBase):
         success, vm = docker_cloud.updateVMInfo(vm, auth)
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
         self.activate_swarm()
@@ -232,7 +232,7 @@ class TestDockerConnector(TestCloudConnectorBase):
         docker_cloud._swarm = None
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
     @patch('requests.request')

--- a/test/unit/connectors/EC2.py
+++ b/test/unit/connectors/EC2.py
@@ -177,10 +177,10 @@ class TestEC2Connector(TestCloudConnectorBase):
         success, _ = res[0]
         self.assertTrue(success, msg="ERROR: launching a VM.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
-        self.assertEquals(len(conn.create_security_group.call_args_list), 3)
-        self.assertEquals(conn.create_security_group.call_args_list[0][0][0], "im-%s" % inf.id)
-        self.assertEquals(conn.create_security_group.call_args_list[1][0][0], "sgname")
-        self.assertEquals(conn.create_security_group.call_args_list[2][0][0], "im-%s-net2" % inf.id)
+        self.assertEqual(len(conn.create_security_group.call_args_list), 3)
+        self.assertEqual(conn.create_security_group.call_args_list[0][0][0], "im-%s" % inf.id)
+        self.assertEqual(conn.create_security_group.call_args_list[1][0][0], "sgname")
+        self.assertEqual(conn.create_security_group.call_args_list[2][0][0], "im-%s-net2" % inf.id)
 
         # Check the case that we do not use VPC
         radl_data = """
@@ -225,10 +225,10 @@ class TestEC2Connector(TestCloudConnectorBase):
         self.assertTrue(success, msg="ERROR: launching a VM.")
         # check the instance_type selected is correct
         self.assertIn(".micro", conn.run_instances.call_args_list[1][1]["instance_type"])
-        self.assertEquals(conn.create_vpc.call_args_list[0][0][0], "10.0.128.0/22")
-        self.assertEquals(conn.create_subnet.call_args_list[0][0], ('vpc-id', '10.0.128.0/24'))
-        self.assertEquals(conn.create_subnet.call_args_list[1][0], ('vpc-id', '10.0.129.0/24'))
-        self.assertEquals(conn.create_subnet.call_args_list[2][0], ('vpc-id', '10.0.130.0/24'))
+        self.assertEqual(conn.create_vpc.call_args_list[0][0][0], "10.0.128.0/22")
+        self.assertEqual(conn.create_subnet.call_args_list[0][0], ('vpc-id', '10.0.128.0/24'))
+        self.assertEqual(conn.create_subnet.call_args_list[1][0], ('vpc-id', '10.0.129.0/24'))
+        self.assertEqual(conn.create_subnet.call_args_list[2][0], ('vpc-id', '10.0.130.0/24'))
 
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
@@ -400,11 +400,11 @@ class TestEC2Connector(TestCloudConnectorBase):
         self.assertTrue(success, msg="ERROR: updating VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
-        self.assertEquals(dns_conn.create_zone.call_count, 1)
-        self.assertEquals(dns_conn.create_zone.call_args_list[0][0][0], "domain.com.")
-        self.assertEquals(changes.add_change.call_args_list, [call('CREATE', 'test.domain.com.', 'A')])
-        self.assertEquals(change.add_value.call_args_list, [call('158.42.1.1')])
-        self.assertEquals(conn.create_route.call_args_list, [call('routet-id', '10.0.10.0/24', instance_id='int-id')])
+        self.assertEqual(dns_conn.create_zone.call_count, 1)
+        self.assertEqual(dns_conn.create_zone.call_args_list[0][0][0], "domain.com.")
+        self.assertEqual(changes.add_change.call_args_list, [call('CREATE', 'test.domain.com.', 'A')])
+        self.assertEqual(change.add_value.call_args_list, [call('158.42.1.1')])
+        self.assertEqual(conn.create_route.call_args_list, [call('routet-id', '10.0.10.0/24', instance_id='int-id')])
 
     @patch('IM.connectors.EC2.EC2CloudConnector.get_connection')
     def test_30_updateVMInfo_spot(self, get_connection):
@@ -690,17 +690,17 @@ class TestEC2Connector(TestCloudConnectorBase):
         self.assertTrue(success, msg="ERROR: finalizing VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
-        self.assertEquals(dns_conn.delete_hosted_zone.call_count, 1)
-        self.assertEquals(dns_conn.delete_hosted_zone.call_args_list[0][0][0], zone.id)
-        self.assertEquals(changes.add_change.call_args_list, [call('DELETE', 'test.domain.com.', 'A')])
-        self.assertEquals(change.add_value.call_args_list, [call('158.42.1.1')])
-        self.assertEquals(sg.delete.call_args_list, [call()])
-        self.assertEquals(sg1.delete.call_args_list, [])
-        self.assertEquals(sg2.delete.call_args_list, [call()])
-        self.assertEquals(conn.delete_subnet.call_args_list, [call('subnet-id')])
-        self.assertEquals(conn.delete_vpc.call_args_list, [call('vpc-id')])
-        self.assertEquals(conn.delete_internet_gateway.call_args_list, [call('ig-id')])
-        self.assertEquals(conn.detach_internet_gateway.call_args_list, [call('ig-id', 'vpc-id')])
+        self.assertEqual(dns_conn.delete_hosted_zone.call_count, 1)
+        self.assertEqual(dns_conn.delete_hosted_zone.call_args_list[0][0][0], zone.id)
+        self.assertEqual(changes.add_change.call_args_list, [call('DELETE', 'test.domain.com.', 'A')])
+        self.assertEqual(change.add_value.call_args_list, [call('158.42.1.1')])
+        self.assertEqual(sg.delete.call_args_list, [call()])
+        self.assertEqual(sg1.delete.call_args_list, [])
+        self.assertEqual(sg2.delete.call_args_list, [call()])
+        self.assertEqual(conn.delete_subnet.call_args_list, [call('subnet-id')])
+        self.assertEqual(conn.delete_vpc.call_args_list, [call('vpc-id')])
+        self.assertEqual(conn.delete_internet_gateway.call_args_list, [call('ig-id')])
+        self.assertEqual(conn.detach_internet_gateway.call_args_list, [call('ig-id', 'vpc-id')])
 
     @patch('IM.connectors.EC2.EC2CloudConnector.get_connection')
     @patch('time.sleep')

--- a/test/unit/connectors/Fogbow.py
+++ b/test/unit/connectors/Fogbow.py
@@ -298,10 +298,10 @@ class TestFogBowConnector(TestCloudConnectorBase):
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
-        self.assertEquals(vm.info.systems[0].getValue("memory.size"), 1073741824)
-        self.assertEquals(vm.info.systems[0].getValue("disk.1.device"), "/dev/sdb")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("memory.size"), 1073741824)
+        self.assertEqual(vm.info.systems[0].getValue("disk.1.device"), "/dev/sdb")
 
         data = json.loads(requests.call_args_list[1][1]["data"])
         self.assertEqual(data["computeId"], '1')

--- a/test/unit/connectors/GCE.py
+++ b/test/unit/connectors/GCE.py
@@ -296,14 +296,14 @@ class TestGCEConnector(TestCloudConnectorBase):
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
 
-        self.assertEquals(dns_driver.create_zone.call_count, 1)
-        self.assertEquals(dns_driver.create_record.call_count, 1)
-        self.assertEquals(dns_driver.create_zone.call_args_list[0], call('domain.com.'))
-        self.assertEquals(dns_driver.create_record.call_args_list[0][0][0], 'test.domain.com.')
-        self.assertEquals(dns_driver.create_record.call_args_list[0][0][2], 'A')
-        self.assertEquals(dns_driver.create_record.call_args_list[0][0][3], {'rrdatas': ['158.42.1.1'], 'ttl': 300})
-        self.assertEquals(vm.info.systems[0].getValue('gpu.count'), 1)
-        self.assertEquals(vm.info.systems[0].getValue('gpu.model'), 'nvidia-tesla-v100')
+        self.assertEqual(dns_driver.create_zone.call_count, 1)
+        self.assertEqual(dns_driver.create_record.call_count, 1)
+        self.assertEqual(dns_driver.create_zone.call_args_list[0], call('domain.com.'))
+        self.assertEqual(dns_driver.create_record.call_args_list[0][0][0], 'test.domain.com.')
+        self.assertEqual(dns_driver.create_record.call_args_list[0][0][2], 'A')
+        self.assertEqual(dns_driver.create_record.call_args_list[0][0][3], {'rrdatas': ['158.42.1.1'], 'ttl': 300})
+        self.assertEqual(vm.info.systems[0].getValue('gpu.count'), 1)
+        self.assertEqual(vm.info.systems[0].getValue('gpu.model'), 'nvidia-tesla-v100')
 
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
@@ -327,7 +327,7 @@ class TestGCEConnector(TestCloudConnectorBase):
 
         self.assertTrue(success, msg="ERROR: stopping VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
-        self.assertEquals(driver.ex_stop_node.call_args_list, [call(node)])
+        self.assertEqual(driver.ex_stop_node.call_args_list, [call(node)])
 
     @patch('libcloud.compute.drivers.gce.GCENodeDriver')
     def test_50_start(self, get_driver):
@@ -349,7 +349,7 @@ class TestGCEConnector(TestCloudConnectorBase):
 
         self.assertTrue(success, msg="ERROR: stopping VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
-        self.assertEquals(driver.ex_start_node.call_args_list, [call(node)])
+        self.assertEqual(driver.ex_start_node.call_args_list, [call(node)])
 
     @patch('libcloud.compute.drivers.gce.GCENodeDriver')
     def test_52_reboot(self, get_driver):
@@ -371,7 +371,7 @@ class TestGCEConnector(TestCloudConnectorBase):
 
         self.assertTrue(success, msg="ERROR: stopping VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
-        self.assertEquals(driver.reboot_node.call_args_list, [call(node)])
+        self.assertEqual(driver.reboot_node.call_args_list, [call(node)])
 
     @patch('libcloud.compute.drivers.gce.GCENodeDriver')
     @patch('libcloud.dns.drivers.google.GoogleDNSDriver')
@@ -439,12 +439,12 @@ class TestGCEConnector(TestCloudConnectorBase):
 
         self.assertTrue(success, msg="ERROR: finalizing VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
-        self.assertEquals(dns_driver.delete_record.call_count, 1)
-        self.assertEquals(dns_driver.delete_record.call_args_list[0][0][0].name, 'test.domain.com.')
-        self.assertEquals(node.destroy.call_args_list, [call()])
-        self.assertEquals(net.destroy.call_args_list, [call()])
-        self.assertEquals(fw.destroy.call_args_list, [call()])
-        self.assertEquals(route.destroy.call_args_list, [call()])
+        self.assertEqual(dns_driver.delete_record.call_count, 1)
+        self.assertEqual(dns_driver.delete_record.call_args_list[0][0][0].name, 'test.domain.com.')
+        self.assertEqual(node.destroy.call_args_list, [call()])
+        self.assertEqual(net.destroy.call_args_list, [call()])
+        self.assertEqual(fw.destroy.call_args_list, [call()])
+        self.assertEqual(route.destroy.call_args_list, [call()])
 
     def test_70_get_custom_instance(self):
         radl_data = """
@@ -462,8 +462,8 @@ class TestGCEConnector(TestCloudConnectorBase):
         driver = MagicMock()
         driver.list_sizes.return_value = [size]
         instance = gce_cloud.get_instance_type(driver, radl.systems[0])
-        self.assertEquals(instance.name, "custom-2-2048")
-        self.assertEquals(instance.extra['selfLink'], "/some/path/custom-2-2048")
+        self.assertEqual(instance.name, "custom-2-2048")
+        self.assertEqual(instance.extra['selfLink'], "/some/path/custom-2-2048")
 
         size2 = MagicMock()
         size2.extra = {"selfLink": "/some/path/sizenamne", "guestCpus": 2}
@@ -471,7 +471,7 @@ class TestGCEConnector(TestCloudConnectorBase):
         size2.name = "sizenamne"
         driver.list_sizes.return_value = [size, size2]
         instance = gce_cloud.get_instance_type(driver, radl.systems[0])
-        self.assertEquals(instance.name, "sizenamne")
+        self.assertEqual(instance.name, "sizenamne")
 
     @patch('libcloud.compute.drivers.gce.GCENodeDriver')
     def test_get_cloud_info(self, get_driver):

--- a/test/unit/connectors/Linode.py
+++ b/test/unit/connectors/Linode.py
@@ -210,12 +210,12 @@ class TestLinodeConnector(TestCloudConnectorBase):
         self.assertEqual(driver.create_volume.call_args_list[0][0][1], 10)
         self.assertEqual(driver.create_volume.call_args_list[0][1]['node'], node)
 
-        self.assertEquals(dns_driver.create_zone.call_count, 1)
-        self.assertEquals(dns_driver.create_record.call_count, 1)
-        self.assertEquals(dns_driver.create_zone.call_args_list[0][0][0], 'domain.com')
-        self.assertEquals(dns_driver.create_record.call_args_list[0][0][0], 'test')
-        self.assertEquals(dns_driver.create_record.call_args_list[0][0][2], 'A')
-        self.assertEquals(dns_driver.create_record.call_args_list[0][0][3], '8.8.8.8')
+        self.assertEqual(dns_driver.create_zone.call_count, 1)
+        self.assertEqual(dns_driver.create_record.call_count, 1)
+        self.assertEqual(dns_driver.create_zone.call_args_list[0][0][0], 'domain.com')
+        self.assertEqual(dns_driver.create_record.call_args_list[0][0][0], 'test')
+        self.assertEqual(dns_driver.create_record.call_args_list[0][0][2], 'A')
+        self.assertEqual(dns_driver.create_record.call_args_list[0][0][3], '8.8.8.8')
 
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 

--- a/test/unit/connectors/OpenNebula.py
+++ b/test/unit/connectors/OpenNebula.py
@@ -190,8 +190,8 @@ class TestONEConnector(TestCloudConnectorBase):
         server_proxy.return_value = one_server
 
         success, vm = one_cloud.updateVMInfo(vm, auth)
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.01")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "158.42.1.1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.01")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "158.42.1.1")
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())

--- a/test/unit/connectors/OpenStack.py
+++ b/test/unit/connectors/OpenStack.py
@@ -424,17 +424,17 @@ class TestOSTConnector(TestCloudConnectorBase):
         success, vm = ost_cloud.updateVMInfo(vm, auth)
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ipv6"), "fec0:4801:7808:52:16:3eff:fe6e:b7e2")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
-        self.assertEquals(driver.ex_update_subnet.call_args_list[0][0][0].id, "subnet1")
-        self.assertEquals(driver.ex_update_subnet.call_args_list[0][1],
-                          {'host_routes': [{'nexthop': '10.0.0.1', 'destination': '10.0.0.0/16'}]})
-        self.assertEquals(vm.info.systems[0].getValue("disk.1.device"), "vdb")
-        self.assertEquals(vm.info.systems[0].getValue("disk.1.image.url"), "ost://server.com/vol1")
-        self.assertEquals(vm.info.systems[0].getValue("gpu.count"), 1)
-        self.assertEquals(vm.info.systems[0].getValue("gpu.model"), 'Tesla V100')
-        self.assertEquals(vm.info.systems[0].getValue("gpu.vendor"), 'NVIDIA')
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ipv6"), "fec0:4801:7808:52:16:3eff:fe6e:b7e2")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(driver.ex_update_subnet.call_args_list[0][0][0].id, "subnet1")
+        self.assertEqual(driver.ex_update_subnet.call_args_list[0][1],
+                         {'host_routes': [{'nexthop': '10.0.0.1', 'destination': '10.0.0.0/16'}]})
+        self.assertEqual(vm.info.systems[0].getValue("disk.1.device"), "vdb")
+        self.assertEqual(vm.info.systems[0].getValue("disk.1.image.url"), "ost://server.com/vol1")
+        self.assertEqual(vm.info.systems[0].getValue("gpu.count"), 1)
+        self.assertEqual(vm.info.systems[0].getValue("gpu.model"), 'Tesla V100')
+        self.assertEqual(vm.info.systems[0].getValue("gpu.vendor"), 'NVIDIA')
 
         # In this case the Node has the float ip assigned
         # node.public_ips = ['8.8.8.8']
@@ -445,14 +445,14 @@ class TestOSTConnector(TestCloudConnectorBase):
         success, vm = ost_cloud.updateVMInfo(vm, auth)
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
 
         # In this case the Node addresses are not available and it uses the old method
         node.extra = {'flavorId': 'small'}
         success, vm = ost_cloud.updateVMInfo(vm, auth)
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
 
@@ -468,8 +468,8 @@ class TestOSTConnector(TestCloudConnectorBase):
 
         success, vm = ost_cloud.updateVMInfo(vm, auth)
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ipv6"), "2001:630:12:581:f816:3eff:fe92:2146")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ipv6"), "2001:630:12:581:f816:3eff:fe92:2146")
 
         url = 'https://nsupdate.fedcloud.eu/nic/update?hostname=test.domain.com&myip=8.8.8.8'
         self.assertEqual(request.call_args_list[0][0][0], url)
@@ -956,13 +956,13 @@ class TestOSTConnector(TestCloudConnectorBase):
 
         self.maxDiff = None
         res = ost_cloud.get_quotas(auth)
-        self.assertEquals(res, {"cores": {"used": 2, "limit": 4},
-                                "ram": {"used": 2, "limit": 4},
-                                "instances": {"used": 2, "limit": 4},
-                                "floating_ips": {"used": 4, "limit": 6},
-                                "security_groups": {"used": 4, "limit": 6},
-                                'volume_storage': {'limit': 6, 'used': 4},
-                                'volumes': {'limit': 6, 'used': 4}})
+        self.assertEqual(res, {"cores": {"used": 2, "limit": 4},
+                               "ram": {"used": 2, "limit": 4},
+                               "instances": {"used": 2, "limit": 4},
+                               "floating_ips": {"used": 4, "limit": 6},
+                               "security_groups": {"used": 4, "limit": 6},
+                               'volume_storage': {'limit': 6, 'used': 4},
+                               'volumes': {'limit': 6, 'used': 4}})
 
     @patch('libcloud.compute.drivers.openstack.OpenStackNodeDriver')
     def test_get_driver(self, get_driver):

--- a/test/unit/connectors/Orange.py
+++ b/test/unit/connectors/Orange.py
@@ -293,12 +293,12 @@ class TestOrangeConnector(TestCloudConnectorBase):
         success, vm = ora_cloud.updateVMInfo(vm, auth)
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
-        self.assertEquals(driver.ex_update_subnet.call_args_list[0][0][0].id, "subnet1")
-        self.assertEquals(driver.ex_update_subnet.call_args_list[0][1],
-                          {'host_routes': [{'nexthop': '10.0.0.1', 'destination': '10.0.0.0/16'}]})
-        self.assertEquals(vm.info.systems[0].getValue("disk.1.device"), "vdb")
-        self.assertEquals(vm.info.systems[0].getValue("disk.1.image.url"), "ora://na-east-0/vol1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(driver.ex_update_subnet.call_args_list[0][0][0].id, "subnet1")
+        self.assertEqual(driver.ex_update_subnet.call_args_list[0][1],
+                         {'host_routes': [{'nexthop': '10.0.0.1', 'destination': '10.0.0.0/16'}]})
+        self.assertEqual(vm.info.systems[0].getValue("disk.1.device"), "vdb")
+        self.assertEqual(vm.info.systems[0].getValue("disk.1.image.url"), "ora://na-east-0/vol1")
 
         # In this case the Node has the float ip assigned
         # node.public_ips = ['8.8.8.8']
@@ -309,14 +309,14 @@ class TestOrangeConnector(TestCloudConnectorBase):
         success, vm = ora_cloud.updateVMInfo(vm, auth)
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
 
         # In this case the Node addresses are not available and it uses the old method
         node.extra = {'flavorId': 'small'}
         success, vm = ora_cloud.updateVMInfo(vm, auth)
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.1.ip"), "10.0.0.1")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
 
         self.assertTrue(success, msg="ERROR: updating VM info.")
 
@@ -332,8 +332,8 @@ class TestOrangeConnector(TestCloudConnectorBase):
 
         success, vm = ora_cloud.updateVMInfo(vm, auth)
         self.assertTrue(success, msg="ERROR: updating VM info.")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
-        self.assertEquals(vm.info.systems[0].getValue("net_interface.0.ipv6"), "2001:630:12:581:f816:3eff:fe92:2146")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ip"), "8.8.8.8")
+        self.assertEqual(vm.info.systems[0].getValue("net_interface.0.ipv6"), "2001:630:12:581:f816:3eff:fe92:2146")
         self.assertNotIn("ERROR", self.log.getvalue(), msg="ERROR found in log: %s" % self.log.getvalue())
 
     @patch('libcloud.compute.drivers.openstack.OpenStackNodeDriver')


### PR DESCRIPTION
Deprecated aliases have been removed in https://github.com/python/cpython/pull/28268